### PR TITLE
replace depricated opencv_python version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 imutils==0.5.4
-opencv_python==4.5.2.52
+opencv_python==4.5.4.58
 img2pdf==0.4.1


### PR DESCRIPTION
Hi Kaushikj,
I've got an interest in your repo usage but didn't work with me due to the depreciation of the OpenCV version in the requirements file so fixed it tested it in a virtual environment and made this request with the updated version.
Best Regards,
Kareem